### PR TITLE
Use mock in jwt auth tests to assert call count

### DIFF
--- a/travelbear/api_public/auth/auth_decorators_test.py
+++ b/travelbear/api_public/auth/auth_decorators_test.py
@@ -1,6 +1,8 @@
+from unittest.mock import Mock
+
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 from cryptography.hazmat.backends import default_backend
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 from django.test import RequestFactory
 import jwt
 import pytest
@@ -18,7 +20,7 @@ def make_jwt_token(sub="test-sub", valid=True):
     if not valid:
         return jwt.encode(
             payload, test_private_key, algorithm=algorithm, headers={"exp": 1000}
-        )  # exp in past
+        )
     return jwt.encode(payload, test_private_key, algorithm=algorithm)
 
 
@@ -27,26 +29,44 @@ def request_factory():
     return RequestFactory()
 
 
-@require_jwt_auth(public_key=test_public_key)
-def protected_endpoint(request, expected_user=None):
-    assert request.user == expected_user
-    return HttpResponse()
+@pytest.fixture
+def get_request(request_factory):
+    def _make_request_with_auth_header(auth_header):
+        return request_factory.get("/", HTTP_AUTHORIZATION=auth_header)
+
+    return _make_request_with_auth_header
+
+
+@pytest.fixture
+def mock_request_handler():
+    return Mock(return_value=HttpResponse(status=200))
 
 
 @pytest.mark.parametrize(
     "authorization",
     ("", "foo", "Bearer: foo", f"Bearer: {make_jwt_token(valid=False)}"),
 )
-def test_require_jwt_auth_not_authenticated(request_factory, authorization):
-    request = request_factory.get("/", HTTP_AUTHORIZATION=authorization)
-    response = protected_endpoint(request)
+def test_require_jwt_auth_not_authenticated(
+    get_request, mock_request_handler, authorization
+):
+    protected_func = require_jwt_auth(mock_request_handler, public_key=test_public_key)
+    response = protected_func(get_request(authorization))
+
     assert response.status_code == 401
+    assert mock_request_handler.call_count == 0
 
 
-def test_require_jwt_auth_authenticated(request_factory):
+def test_require_jwt_auth_authenticated(get_request, mock_request_handler):
     token = make_jwt_token(sub="test-sub")
     authorization = f"Bearer: {token.decode()}"
 
-    request = request_factory.get("/", HTTP_AUTHORIZATION=authorization)
-    result = protected_endpoint(request, expected_user="test-sub")
-    assert result.status_code == 200
+    protected_func = require_jwt_auth(mock_request_handler, public_key=test_public_key)
+    response = protected_func(get_request(authorization))
+
+    assert response.status_code == 200
+    assert mock_request_handler.call_count == 1
+
+    args, kwargs = mock_request_handler.call_args
+    request_received = args[0]
+    assert isinstance(request_received, HttpRequest)
+    assert getattr(request_received, "user") == "test-sub"


### PR DESCRIPTION
This PR:
 - Uses `unittest.mock` to make more in-depth assertions on the calling of request handlers protected by `require_jwt_auth`