### PR TITLE
Simplify circle build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,14 @@ jobs:
         command: |
           docker-compose build
     - run:
-        name: Start services
-        command: |
-          docker-compose up -d
-    - run:
         name: Run tests
         command: |
-          docker-compose exec -e DB_HOST=db -e stack=test server \
-          pytest --doctest-modules -W ignore::DeprecationWarning travelbear
+          docker-compose run -e stack=test server \
+            pytest --pyargs --doctest-modules --rootdir travelbear .
     - run:
         name: Run linter
         command: |
-          docker-compose exec -e stack=test server \
-          black --fast --check --exclude db_layer/migrations travelbear
+          docker-compose run -e stack=test server \
+            black --fast --check --exclude db_layer/migrations travelbear
     - store_test_results:
         path: test-results

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,5 +4,3 @@ services:
   server:
     volumes:
       - .:/usr/src/app
-    environment:
-      - DB_HOST=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
 
   server:
     build: .
-    command: python travelbear/manage.py runserver 0.0.0.0:8000
     environment:
       - DJANGO_SETTINGS_MODULE=django_conf.settings
+      - DB_HOST=db
+      - stack=development
     depends_on:
       - db
     ports:


### PR DESCRIPTION
This PR:
 - Simplifies the circle build pipeline by using `docker-compose run` commands directly instead of starting services and `exec`-ing commands into them.