### PR TITLE
Fix pytest problem on circleci

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
   server:
     build: .
     command: python travelbear/manage.py runserver 0.0.0.0:8000
-    volumes:
-      - .:/usr/src/app
     environment:
       - DJANGO_SETTINGS_MODULE=django_conf.settings
       - DB_HOST=db


### PR DESCRIPTION
#### This PR
 - Fixes a problem on Circle CI where the use of volumes in `docker-compose.yml` caused it to fail finding the rootdir

```
ERROR: Directory '/usr/src/app/travelbear' not found. Check your '--rootdir' option.
```
