### PR TITLE
remove status option from validation_error_response

### DIFF
--- a/travelbear/api_public/trips/views/create_location.py
+++ b/travelbear/api_public/trips/views/create_location.py
@@ -16,7 +16,7 @@ def create_location_handler(request, trip_id):
 
     event = parse_location_from_request_body(request.body)
     if not event.is_valid:
-        return validation_error_response(validation_errors=event.validation_errors)
+        return validation_error_response(event.validation_errors)
 
     location = persist_location(db_trip, event)
     return success_response(status=201, data=location)

--- a/travelbear/api_public/trips/views/create_trip.py
+++ b/travelbear/api_public/trips/views/create_trip.py
@@ -12,7 +12,7 @@ from ..models.trip import Trip
 def create_trip_handler(request):
     trip = get_trip_from_request_body(request.body)
     if not trip.is_valid:
-        return validation_error_response(validation_errors=trip.validation_errors)
+        return validation_error_response(trip.validation_errors)
 
     created_trip = persist_trip(trip, created_by=request.user)
     return success_response(status=201, data=created_trip)

--- a/travelbear/api_public/trips/views/update_location.py
+++ b/travelbear/api_public/trips/views/update_location.py
@@ -24,7 +24,7 @@ def update_location_handler(request, trip_id, location_id):
         request.user, location, request_body
     )
     if error:
-        return validation_error_response(validation_errors=[error])
+        return validation_error_response([error])
 
     return success_response(data=Location.from_db_model(updated_location))
 

--- a/travelbear/api_public/trips/views/update_trip.py
+++ b/travelbear/api_public/trips/views/update_trip.py
@@ -21,7 +21,5 @@ def update_trip_handler(request, trip_id):
     try:
         updated_trip = update_trip(request.user, db_trip, **parsed_body)
     except UpdateNotAllowed:
-        return validation_error_response(
-            validation_errors=["Cannot update one or more requested fields"]
-        )
+        return validation_error_response(["Cannot update one or more requested fields"])
     return success_response(data=Trip.from_db_model(updated_trip))

--- a/travelbear/common/response/error_response.py
+++ b/travelbear/common/response/error_response.py
@@ -14,7 +14,7 @@ def error_response(status=400, message=None):
     return JsonResponse(data, status=status)
 
 
-def validation_error_response(status=400, validation_errors=None):
+def validation_error_response(validation_errors):
     data = {"ok": False}
     if not isinstance(validation_errors, (list, type(None))):
         logger.warning(
@@ -24,4 +24,4 @@ def validation_error_response(status=400, validation_errors=None):
     if validation_errors is not None:
         data.update({"validation_errors": validation_errors})
 
-    return JsonResponse(data, status=status)
+    return JsonResponse(data, status=400)

--- a/travelbear/common/response/error_response_test.py
+++ b/travelbear/common/response/error_response_test.py
@@ -23,18 +23,16 @@ def test_error_response(status, message):
 
 
 @pytest.mark.parametrize(
-    "status,validation_errors",
-    ((400, None), (401, ["foo is a required field", "bar must be a positive number"])),
+    "validation_errors",
+    ((None), (["foo is a required field", "bar must be a positive number"])),
 )
-def test_validation_error_response(status, validation_errors):
-    response = validation_error_response(
-        status=status, validation_errors=validation_errors
-    )
+def test_validation_error_response(validation_errors):
+    response = validation_error_response(validation_errors=validation_errors)
 
     expected_response_data = {"ok": False}
     if validation_errors is not None:
         expected_response_data.update({"validation_errors": validation_errors})
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == status
+    assert response.status_code == 400
     assert json.loads(response.content) == expected_response_data

--- a/travelbear/django_conf/settings.py
+++ b/travelbear/django_conf/settings.py
@@ -27,7 +27,9 @@ DB_NAME = os.getenv("DB_NAME", "postgres")
 DB_USER = os.getenv("DB_USER", "postgres")
 DB_PASSWORD = os.getenv("DB_PASSWORD", "")
 DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
-SECRET_KEY = os.getenv("SECRET_KEY", "DEVKEY^0pu&rp0el9zzx*xb39bu=vo7qlgyx3m%&dariuwa3o_")
+SECRET_KEY = os.getenv(
+    "SECRET_KEY", "DEVKEY^0pu&rp0el9zzx*xb39bu=vo7qlgyx3m%&dariuwa3o_"
+)
 
 
 DEBUG = IS_DEV_ENVIRONMENT


### PR DESCRIPTION
#### This PR
 - Removes the `status=` opt from `validation_error_response` as they should always return HTTP 400