### PR TITLE
Users saved to DB on authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,6 @@ prod:
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml \
 		up
 
-test:
-	docker-compose -f docker-compose.dev.yml -f docker-compose.yml \
-		run --rm -e stack=test server pytest \
-		--doctest-modules --rootdir travelbear --pyargs "$(pkg)"
-
 lint:
 	docker-compose -f docker-compose.dev.yml -f docker-compose.yml \
 		run --rm --no-deps server black \

--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ Installation instructions are at [docs.docker.com/install](https://docs.docker.c
 
 #### Scripts
 
-Some useful scripts are defined in `Makefile`.
+The test suite can be run with `./run-tests.sh`.
+```py
+# to run a specific package or module
+./run-tests.sh api_public.auth
+# to run a specific test
+./run-tests.sh api_public.auth.auth_decorators_test::test_require_jwt_auth_authenticated
+```
 
- - `make test` runs the test suite.
-To test a specific package specify it with `pkg`.
-e.g. `make test pkg=api_public.auth`.
+Other useful scripts are defined in `Makefile`.
+
  - `make lint` lints your code for you, be sure to do this before pushing to GitHub as CircleCI
 rejects unlinted code.
  - `make ssh` starts a shell on the local server so you can execute arbitrary commands.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker-compose -f docker-compose.dev.yml -f docker-compose.yml \
+    run --rm -e stack=test server pytest \
+    --doctest-modules --rootdir travelbear --pyargs "$@"


### PR DESCRIPTION
#### This PR
 - Updates `require_jwt_auth` to save users if they're not in the DB
 - Reverts to `run-tests.sh` for ease of development (can more easily test individual tests)