### PR TITLE
Log warning if setting from env is not set

### DIFF
--- a/Gatekeeper/gatekeeper/django_conf/settings.py
+++ b/Gatekeeper/gatekeeper/django_conf/settings.py
@@ -10,7 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -59,7 +62,7 @@ for setting_name in SETTINGS_FROM_ENVIRONMENT:
 
 for setting_name in SETTINGS_FROM_ENVIRONMENT:
     if vars()[setting_name] is None:
-        raise EnvironmentError(f"{setting_name} is not set")
+        logger.warning(f"Missing setting {setting_name}: set with environment variable")
 
 
 if ENVIRONMENT not in ALLOWED_ENVIRONMENTS:


### PR DESCRIPTION
Erroring was causing problems with management commands (needed TWILIO keys to be set to run migrations for example)